### PR TITLE
fix: deixa compatível a versão 4.5(LTS) compatível com a 4.0

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -24,17 +24,34 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$messageproviders = [
-    'timelineposts' => [
-        'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
-            'email' => MESSAGE_PERMITTED
+if (defined(MESSAGE_DEFAULT_LOGGEDIN) && defined(MESSAGE_DEFAULT_LOGGEDOFF) ) {
+    $messageproviders = [
+        'timelineposts' => [
+            'defaults' => [
+                'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+                'email' => MESSAGE_PERMITTED
+            ]
+        ],
+        'postmention' => [
+            'defaults' => [
+                'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+                'email' => MESSAGE_PERMITTED
+            ]
         ]
-    ],
-    'postmention' => [
-        'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
-            'email' => MESSAGE_PERMITTED
+    ];
+} else {
+    $messageproviders = [
+        'timelineposts' => [
+            'defaults' => [
+                'popup' => MESSAGE_PERMITTED,
+                'email' => MESSAGE_PERMITTED
+            ]
+        ],
+        'postmention' => [
+            'defaults' => [
+                'popup' => MESSAGE_PERMITTED,
+                'email' => MESSAGE_PERMITTED
+            ]
         ]
-    ]
-];
+    ];
+}

--- a/db/messages.php
+++ b/db/messages.php
@@ -43,13 +43,13 @@ if (defined(MESSAGE_DEFAULT_LOGGEDIN) && defined(MESSAGE_DEFAULT_LOGGEDOFF) ) {
     $messageproviders = [
         'timelineposts' => [
             'defaults' => [
-                'popup' => MESSAGE_PERMITTED,
+                'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
                 'email' => MESSAGE_PERMITTED
             ]
         ],
         'postmention' => [
             'defaults' => [
-                'popup' => MESSAGE_PERMITTED,
+                'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
                 'email' => MESSAGE_PERMITTED
             ]
         ]

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023100902;
+$plugin->version   = 2025052103;
 $plugin->requires  = 2023100400;
 $plugin->component = 'format_timeline';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '4.3.0';
+$plugin->release   = '4.5.0';


### PR DESCRIPTION
Conforme o lib/upgrade.txt, a partir da versão 4.0:

> Loggedin / Loggedoff component settings on notification preferences have been merged to a single enabled switch:
  `MESSAGE_DEFAULT_LOGGEDIN` and `MESSAGE_DEFAULT_LOGGEDOFF` are now *deprecated*, so plugins should be updated if `db/messages.php` is present and replace `MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF` to `MESSAGE_DEFAULT_ENABLED`. Backward compatibility will take any of both settings as enabled.